### PR TITLE
Monitor Edge Agent secrets

### DIFF
--- a/crd/sparkplug-node.yaml
+++ b/crd/sparkplug-node.yaml
@@ -29,6 +29,7 @@ spec:
               x-kubernetes-validations:
                 - rule: "has(self.uuid) != has(self.address)"
                 - rule: "has(self.uuid) || !self.edgeAgent"
+                - rule: "self.edgeAgent || !has(self.secrets)"
               properties:
                 uuid:
                   description: Sparkplug Node UUID
@@ -47,6 +48,11 @@ spec:
                   description: Liveness check interval
                   type: string
                   format: duration
+                secrets:
+                  description: Names of SealedSecrets we use.
+                  type: array
+                  items:
+                    type: string
             status:
               type: object
       subresources:

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -69,7 +69,6 @@ export class Monitor {
         this.cdb_watch = await this.fplus.ConfigDB.watcher();
 
         this.node_checks.subscribe();
-        this.secrets.subscribe(v => this.log("SECRET: %o", v.toJS()));
     }
 
     /* Watch the SparkplugNode objects on the cluster. Publishes

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -22,6 +22,20 @@ const NodeSpec = imm.Record({
     interval:   "3m",
 });
 
+const SecretStatus = imm.Record({
+    uuid:           null,
+    generation:     null,
+    observed:       null,
+    synced:         null,
+});
+SecretStatus.of = obj => SecretStatus({
+    uuid:           obj.metadata.uid,
+    generation:     obj.metadata.generation,
+    observed:       obj.status?.observedGeneration,
+    synced:         !!obj.status?.conditions
+                        ?.some(c => c.type == "Synced" && c.status == "True"),
+});
+
 export class Monitor {
     constructor (opts) {
         this.fplus      = opts.fplus;
@@ -38,6 +52,7 @@ export class Monitor {
         const nodes = this._init_nodes();
         const [starts, stops] = this._node_start_stops(nodes);
         this.node_checks = this._init_node_checks(starts, stops);
+        this.secrets = this._init_secrets();
 
         return this;
     }
@@ -49,6 +64,7 @@ export class Monitor {
         this.cdb_watch = await this.fplus.ConfigDB.watcher();
 
         this.node_checks.subscribe();
+        this.secrets.subscribe(v => this.log("SECRET: %o", v.toJS()));
     }
 
     /* Watch the SparkplugNode objects on the cluster. Publishes
@@ -123,6 +139,22 @@ export class Monitor {
                     rx.finalize(() => this.log("STOP: %s", uuid)),
                 );
             }),
+        );
+    }
+
+    _init_secrets () {
+        return rxx.k8s_watch({
+            k8s,
+            kubeconfig:     this.kubeconfig,
+            errors:         e => this.log("SealedSecret watch error: %s", e),
+            apiVersion:     "bitnami.com/v1alpha1",
+            kind:           "SealedSecret",
+            namespace:      this.namespace,
+            key:            obj => obj.metadata.name,
+            value:          obj => SecretStatus.of(obj),
+        }).pipe(
+            rx.tap({ subscribe: () => this.log("SS subscribe") }),
+            rxx.shareLatest(),
         );
     }
 }

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -129,11 +129,7 @@ export class Monitor {
                     rx.filter(stop => stop.uuid == spec.uuid),
                 );
 
-                const MClass = spec.edgeAgent ? AgentMonitor : NodeMonitor;
-                const monitor = new MClass({ 
-                    ...spec,
-                    operator:   this,
-                });
+                const monitor = NodeMonitor.of(this, spec);
                 this.log("Using monitor %s for %s", monitor, spec.uuid);
 
                 /* Run the monitor checks until we get a stop */

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -4,16 +4,13 @@
  * Copyright 2023 AMRC
  */
 
-import util         from "util";
-
 import imm          from "immutable";
 import rx           from "rxjs";
 import k8s          from "@kubernetes/client-node";
 
 import * as rxx             from "@amrc-factoryplus/rx-util";
 
-import { AgentMonitor, NodeMonitor }    from "./node.js";
-import { App }                          from "./uuids.js";
+import { NodeMonitor }      from "./node.js";
 
 const NodeSpec = imm.Record({
     uuid:       null, 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -118,25 +118,24 @@ export class Monitor {
          * node. Merge the results into our output. */
         return starts.pipe(
             rx.tap(u => this.log("START: %s", u)),
-            rx.flatMap(({edgeAgent, uuid, interval}) => {
+            rx.flatMap(spec => {
                 /* Watch for a stop signal for this node UUID */
                 const stopper = stops.pipe(
-                    rx.filter(stop => stop.uuid == uuid),
+                    rx.filter(stop => stop.uuid == spec.uuid),
                 );
 
-                const MClass = edgeAgent ? AgentMonitor : NodeMonitor;
+                const MClass = spec.edgeAgent ? AgentMonitor : NodeMonitor;
                 const monitor = new MClass({ 
+                    ...spec,
                     operator:   this,
-                    node:       uuid,
-                    interval,
                 });
-                this.log("Using monitor %s for %s", monitor, uuid);
+                this.log("Using monitor %s for %s", monitor, spec.uuid);
 
                 /* Run the monitor checks until we get a stop */
                 return rx.from(monitor.init()).pipe(
                     rx.mergeMap(m => m.checks()),
                     rx.takeUntil(stopper),
-                    rx.finalize(() => this.log("STOP: %s", uuid)),
+                    rx.finalize(() => this.log("STOP: %s", spec.uuid)),
                 );
             }),
         );

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -20,6 +20,11 @@ const NodeSpec = imm.Record({
     address:    null,
     edgeAgent:  false,
     interval:   "3m",
+    secrets:    imm.Set(),
+});
+NodeSpec.of = spec => NodeSpec({
+    ...spec,
+    secrets:    imm.Set(spec.secrets ?? []),
 });
 
 const SecretStatus = imm.Record({
@@ -80,7 +85,7 @@ export class Monitor {
             apiVersion:     "factoryplus.app.amrc.co.uk/v1",
             kind:           "SparkplugNode",
             namespace:      this.namespace,
-            value:          obj => NodeSpec(obj.spec),
+            value:          obj => NodeSpec.of(obj.spec),
         }).pipe(
             /* We only care about the objects, not the k8s UUIDs, and we
              * can only handle Nodes with F+ UUIDs. */

--- a/lib/node.js
+++ b/lib/node.js
@@ -126,6 +126,7 @@ export class NodeMonitor {
 export class AgentMonitor extends NodeMonitor {
     constructor (opts) {
         super(opts);
+        this.secrets = imm.Set(opts.secrets);
     }
 
     async init () {
@@ -136,6 +137,11 @@ export class AgentMonitor extends NodeMonitor {
 
         /* Watch our config entry in the CDB */
         this.config = this._init_config();
+
+        /* Watch for Secret changes we care about */
+        this.secret_changed = this._init_secret_changed();
+        this.secret_changed.subscribe(v => 
+            this.log("SECRET CHANGED [%s]: %o", this.node, v));
 
         /* Check for updates to the config file */
         this._checks.push(this._init_config_updates());
@@ -208,6 +214,15 @@ export class AgentMonitor extends NodeMonitor {
             rx.switchMap(() => cdb.get_config_etag(App.AgentConfig, this.node)),
             /* Skip notifications that don't change our revision UUID */
             rx.distinctUntilChanged(),
+        );
+    }
+
+    /* Emit whenever our Secrets change */
+    _init_secret_changed () {
+        return this.operator.secrets.pipe(
+            rx.map(secrets => secrets
+                .filter((v, k) => this.secrets.has(k))),
+            rx.distinctUntilChanged(imm.is),
         );
     }
 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -143,7 +143,7 @@ export class AgentMonitor extends NodeMonitor {
         /* Watch for Secret changes we care about */
         this.secret_changed = this._init_secret_changed();
         this.secret_changed.subscribe(v => 
-            this.log("SECRET CHANGED [%s]: %o", this.node, v));
+            this.log("SECRET CHANGED [%s]: %o", this.node, v.toJS()));
 
         /* Check for updates to the config file */
         this._checks.push(this._init_config_updates());
@@ -225,6 +225,7 @@ export class AgentMonitor extends NodeMonitor {
             rx.map(secrets => secrets
                 .filter((v, k) => this.spec.secrets.has(k))),
             rx.distinctUntilChanged(imm.is),
+            rx.filter(v => !v.isEmpty()),
         );
     }
 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -4,16 +4,14 @@
  * Copyright 2023 AMRC
  */
 
-import util         from "util";
-
 import imm          from "immutable";
 import duration     from "parse-duration";
 import rx           from "rxjs";
 
-import { Address, UUIDs }   from "@amrc-factoryplus/utilities";
+import { UUIDs }            from "@amrc-factoryplus/utilities";
 import * as rxx             from "@amrc-factoryplus/rx-util";
 
-import { Alert, App } from "./uuids.js";
+import { App }              from "./uuids.js";
 
 export class NodeMonitor {
     constructor (op, spec) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -16,16 +16,23 @@ import * as rxx             from "@amrc-factoryplus/rx-util";
 import { Alert, App } from "./uuids.js";
 
 export class NodeMonitor {
-    constructor (opts) {
-        const op = this.operator = opts.operator;
-        this.node = opts.uuid;
-        this.interval = duration(opts.interval);
+    constructor (op, spec) {
+        this.operator = op;
+        this.spec = spec;
+
+        this.node = spec.uuid;
+        this.interval = duration(spec.interval);
 
         this.fplus = op.fplus;
 
         this.log = this.fplus.debug.log.bind(this.fplus.debug, "node");
 
         this._checks = [];
+    }
+
+    static of (op, spec) {
+        const Klass = spec.edgeAgent ? AgentMonitor : NodeMonitor;
+        return new Klass(op, spec);
     }
 
     async init () {
@@ -124,11 +131,6 @@ export class NodeMonitor {
 }
 
 export class AgentMonitor extends NodeMonitor {
-    constructor (opts) {
-        super(opts);
-        this.secrets = opts.secrets;
-    }
-
     async init () {
         await super.init();
 
@@ -221,7 +223,7 @@ export class AgentMonitor extends NodeMonitor {
     _init_secret_changed () {
         return this.operator.secrets.pipe(
             rx.map(secrets => secrets
-                .filter((v, k) => this.secrets.has(k))),
+                .filter((v, k) => this.spec.secrets.has(k))),
             rx.distinctUntilChanged(imm.is),
         );
     }

--- a/lib/node.js
+++ b/lib/node.js
@@ -126,7 +126,7 @@ export class NodeMonitor {
 export class AgentMonitor extends NodeMonitor {
     constructor (opts) {
         super(opts);
-        this.secrets = imm.Set(opts.secrets);
+        this.secrets = opts.secrets;
     }
 
     async init () {

--- a/lib/node.js
+++ b/lib/node.js
@@ -140,45 +140,30 @@ export class AgentMonitor extends NodeMonitor {
         /* Watch our config entry in the CDB */
         this.config = this._init_config();
 
+        /* Watch for changes to our config file */
+        const config_changed = this._init_config_changed();
+        config_changed.subscribe(v =>
+            this.log("CONFIG CHANGED [%s]: %o", this.node, v));
         /* Watch for Secret changes we care about */
-        this.secret_changed = this._init_secret_changed();
-        this.secret_changed.subscribe(v => 
+        const secret_changed = this._init_secret_changed();
+        secret_changed.subscribe(v => 
             this.log("SECRET CHANGED [%s]: %o", this.node, v.toJS()));
 
-        /* Check for updates to the config file */
-        this._checks.push(this._init_config_updates());
+        /* Check for updates to the config and send reload CMDs */
+        this._checks.push(this._init_config_updates(
+            config_changed, secret_changed));
 
         return this;
     }
 
-    /* Track the Edge Agent's current config revision published over
-     * MQTT, and the latest revision from the ConfigDB. If they don't
-     * match, CMD the EA to reload its config file.
-     */
-    _init_config_updates () {
+    _init_config_updates (...srcs) {
         const cmdesc = this.fplus.CmdEsc;
 
-        /* Collect the most recent values from... */
-        return rx.combineLatest({
-            /* Our EA's Sparkplug address */
-            address: this.device.address,
-            /* Our EA's in-use config revision */
-            device: this.device.metric("Config_Revision")
-                .pipe(rx.shareReplay(1)),
-            /* The ConfigDB's current config revision */
-            config: this.config,
-        }).pipe(
-            /* EA and ConfigDB represent 'no config' differently */
-            rx.map(up => ({ ...up,
-                device: up.device == UUIDs.Null ? undefined : up.device,
-            })),
-            /* If they match, we don't care */
-            rx.filter(up => up.device != up.config),
+        return rx.merge(...srcs).pipe(
+            /* Fetch the current address */
+            rx.withLatestFrom(this.device.address, (src, addr) => addr),
             /* Throttle restarts to once every 5s */
             rx.throttleTime(5000, undefined, { trailing: true }),
-            rx.tap(up => this.log("Config update: %o", up)),
-            /* We only want the address at this point */
-            rx.map(up => up.address),
             /* Make a command escalation request. The Promise from
              * request_cmd will be converted to an Observable. */
             rx.switchMap(addr => cmdesc
@@ -193,6 +178,30 @@ export class AgentMonitor extends NodeMonitor {
                 .then(() => addr)),
             /* We only get here once the request has finished */
             rx.tap(addr => this.log("Sent reload request to %s", addr)),
+        );
+    }
+
+    /* Track the Edge Agent's current config revision published over
+     * MQTT, and the latest revision from the ConfigDB.
+     */
+    _init_config_changed () {
+        /* Our EA's in-use config revision */
+        const device = this.device.metric("Config_Revision").pipe(
+            /* EA and ConfigDB use different representations here */
+            rx.map(u => u == UUIDs.Null ? undefined : u),
+            /* Keep the latest value available */
+            rx.shareReplay(1),
+        );
+
+        /* Collect the most recent values from... */
+        return rx.combineLatest({
+            /* Our EA's in-use config revision */
+            device,
+            /* The ConfigDB's current config revision */
+            config: this.config,
+        }).pipe(
+            /* If they match, we don't care */
+            rx.filter(up => up.device != up.config),
         );
     }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -222,10 +222,16 @@ export class AgentMonitor extends NodeMonitor {
     /* Emit whenever our Secrets change */
     _init_secret_changed () {
         return this.operator.secrets.pipe(
-            rx.map(secrets => secrets
+            /* Pull out the secrets we care about */
+            rx.map(sss => sss
                 .filter((v, k) => this.spec.secrets.has(k))),
+            /* Don't bother until we have something to watch */
+            rx.skipWhile(sss => sss.isEmpty()),
+            /* Skip updates where secrets aren't synced yet */
+            rx.filter(sss => sss.every(ss =>
+                ss.synced && ss.observed == ss.generation)),
+            /* Some updates won't change our secrets */
             rx.distinctUntilChanged(imm.is),
-            rx.filter(v => !v.isEmpty()),
         );
     }
 }

--- a/lib/node.js
+++ b/lib/node.js
@@ -18,7 +18,7 @@ import { Alert, App } from "./uuids.js";
 export class NodeMonitor {
     constructor (opts) {
         const op = this.operator = opts.operator;
-        this.node = opts.node;
+        this.node = opts.uuid;
         this.interval = duration(opts.interval);
 
         this.fplus = op.fplus;

--- a/lib/sparkplug.js
+++ b/lib/sparkplug.js
@@ -36,8 +36,6 @@ export class SparkplugNode {
     }
 
     async init () {
-        const { fplus } = this;
-
         const ids = await this._find_ids();
         this.uuid = ids.uuid;
 


### PR DESCRIPTION
Extend the SparkplugNode CRD to allow specifying the names of SealedSecrets used by an Edge Agent. Whenever the unsealed value of one of these changes, reload the Edge Agent config.